### PR TITLE
DZ-7

### DIFF
--- a/TodoItemCoreData+CoreDataClass.swift
+++ b/TodoItemCoreData+CoreDataClass.swift
@@ -1,0 +1,6 @@
+import Foundation
+import CoreData
+
+public class TodoItemCoreData: NSManagedObject {
+
+}

--- a/TodoItemCoreData+CoreDataProperties.swift
+++ b/TodoItemCoreData+CoreDataProperties.swift
@@ -1,0 +1,23 @@
+import Foundation
+import CoreData
+
+extension TodoItemCoreData {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<TodoItemCoreData> {
+        return NSFetchRequest<TodoItemCoreData>(entityName: "TodoItemCoreData")
+    }
+
+    @NSManaged public var color: String?
+    @NSManaged public var createdDate: Date
+    @NSManaged public var deadline: Date?
+    @NSManaged public var editedDate: Date?
+    @NSManaged public var id: String
+    @NSManaged public var isDone: Bool
+    @NSManaged public var priority: String
+    @NSManaged public var text: String
+
+}
+
+extension TodoItemCoreData: Identifiable {
+
+}

--- a/todo-app-ahc.xcodeproj/project.pbxproj
+++ b/todo-app-ahc.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ahc.todo-app-a-handsome-cat";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -690,7 +690,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ahc.todo-app-a-handsome-cat";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/todo-app-ahc.xcodeproj/project.pbxproj
+++ b/todo-app-ahc.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		FE0085452A4673010049F403 /* UIColor+HEXCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0085442A4673010049F403 /* UIColor+HEXCode.swift */; };
 		FE0085472A4673250049F403 /* TodoListTableViewController+TextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0085462A4673250049F403 /* TodoListTableViewController+TextViewDelegate.swift */; };
 		FE0085492A46794F0049F403 /* NSLayoutConstraints+TableViewCellContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0085482A46794E0049F403 /* NSLayoutConstraints+TableViewCellContentView.swift */; };
+		FE148FE12A619FC2007975AF /* TodoItemCoreData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE148FDF2A619FC2007975AF /* TodoItemCoreData+CoreDataClass.swift */; };
+		FE148FE22A619FC2007975AF /* TodoItemCoreData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE148FE02A619FC2007975AF /* TodoItemCoreData+CoreDataProperties.swift */; };
+		FE148FE62A61F05B007975AF /* FileCache+UniversalFuncs.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE148FE52A61F05B007975AF /* FileCache+UniversalFuncs.swift */; };
 		FE5303FE2A498570005B5A8A /* TodoItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5303FD2A498570005B5A8A /* TodoItemTableViewCell.swift */; };
 		FE5304002A49CC9F005B5A8A /* TodoItem+DateStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5303FF2A49CC9F005B5A8A /* TodoItem+DateStrings.swift */; };
 		FE5304082A4F11B5005B5A8A /* TransitioningAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5304072A4F11B5005B5A8A /* TransitioningAnimationController.swift */; };
@@ -41,6 +44,7 @@
 		FEC83E992A3CF70800FFD551 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC83E982A3CF70800FFD551 /* TestData.swift */; };
 		FEC83E9B2A3CF72C00FFD551 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC83E9A2A3CF72C00FFD551 /* CSVTests.swift */; };
 		FEC83E9D2A3CF76600FFD551 /* ReadWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC83E9C2A3CF76600FFD551 /* ReadWriteTests.swift */; };
+		FECA9C512A6132A90001181C /* TodoItemsModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FECA9C4F2A6132A90001181C /* TodoItemsModel.xcdatamodeld */; };
 		FEF8AA7D2A58EC3600640FB1 /* URLSession+CustomDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF8AA7C2A58EC3600640FB1 /* URLSession+CustomDataTask.swift */; };
 		FEFBFCFB2A54545100D430BC /* DefaultNetworkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFBFCFA2A54545100D430BC /* DefaultNetworkingService.swift */; };
 		FEFBFCFD2A54560400D430BC /* NetworkingServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFBFCFC2A54560400D430BC /* NetworkingServiceProtocol.swift */; };
@@ -77,6 +81,9 @@
 		FE0085442A4673010049F403 /* UIColor+HEXCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+HEXCode.swift"; sourceTree = "<group>"; };
 		FE0085462A4673250049F403 /* TodoListTableViewController+TextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TodoListTableViewController+TextViewDelegate.swift"; sourceTree = "<group>"; };
 		FE0085482A46794E0049F403 /* NSLayoutConstraints+TableViewCellContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraints+TableViewCellContentView.swift"; sourceTree = "<group>"; };
+		FE148FDF2A619FC2007975AF /* TodoItemCoreData+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TodoItemCoreData+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
+		FE148FE02A619FC2007975AF /* TodoItemCoreData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TodoItemCoreData+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
+		FE148FE52A61F05B007975AF /* FileCache+UniversalFuncs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileCache+UniversalFuncs.swift"; sourceTree = "<group>"; };
 		FE5303FD2A498570005B5A8A /* TodoItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoItemTableViewCell.swift; sourceTree = "<group>"; };
 		FE5303FF2A49CC9F005B5A8A /* TodoItem+DateStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TodoItem+DateStrings.swift"; sourceTree = "<group>"; };
 		FE5304072A4F11B5005B5A8A /* TransitioningAnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitioningAnimationController.swift; sourceTree = "<group>"; };
@@ -98,6 +105,7 @@
 		FEC83E982A3CF70800FFD551 /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
 		FEC83E9A2A3CF72C00FFD551 /* CSVTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVTests.swift; sourceTree = "<group>"; };
 		FEC83E9C2A3CF76600FFD551 /* ReadWriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteTests.swift; sourceTree = "<group>"; };
+		FECA9C502A6132A90001181C /* TodoItemsModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TodoItemsModel.xcdatamodel; sourceTree = "<group>"; };
 		FEF8AA7C2A58EC3600640FB1 /* URLSession+CustomDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+CustomDataTask.swift"; sourceTree = "<group>"; };
 		FEFBFCFA2A54545100D430BC /* DefaultNetworkingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkingService.swift; sourceTree = "<group>"; };
 		FEFBFCFC2A54560400D430BC /* NetworkingServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingServiceProtocol.swift; sourceTree = "<group>"; };
@@ -212,6 +220,7 @@
 		FEC83E502A3CF1DA00FFD551 = {
 			isa = PBXGroup;
 			children = (
+				FECA9C4F2A6132A90001181C /* TodoItemsModel.xcdatamodeld */,
 				FEC83E5B2A3CF1DA00FFD551 /* todo-app-ahc */,
 				FEC83E722A3CF1DE00FFD551 /* todo-app-ahcTests */,
 				FEC83E5A2A3CF1DA00FFD551 /* Products */,
@@ -261,9 +270,12 @@
 		FEC83E8F2A3CF63600FFD551 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				FE148FDF2A619FC2007975AF /* TodoItemCoreData+CoreDataClass.swift */,
+				FE148FE02A619FC2007975AF /* TodoItemCoreData+CoreDataProperties.swift */,
 				FEC83E902A3CF64200FFD551 /* ToDoItem.swift */,
 				FEB339892A584378000BE02F /* TodoItemServer.swift */,
 				FEC83E922A3CF66C00FFD551 /* FileCache.swift */,
+				FE148FE52A61F05B007975AF /* FileCache+UniversalFuncs.swift */,
 				FEC83E942A3CF68C00FFD551 /* CSVExtensions.swift */,
 				FEFBFD042A57425700D430BC /* TodoItemsManager.swift */,
 			);
@@ -461,9 +473,11 @@
 				FEC83E612A3CF1DA00FFD551 /* TodoListTableViewController.swift in Sources */,
 				FE5304002A49CC9F005B5A8A /* TodoItem+DateStrings.swift in Sources */,
 				FE0085382A4672270049F403 /* DeadlineTableViewCell.swift in Sources */,
+				FE148FE62A61F05B007975AF /* FileCache+UniversalFuncs.swift in Sources */,
 				FE0085402A4672B30049F403 /* ShowColorPickerTableViewCell.swift in Sources */,
 				FEFBFD052A57425700D430BC /* TodoItemsManager.swift in Sources */,
 				FE0085362A4672050049F403 /* PriorityTableViewCell.swift in Sources */,
+				FE148FE22A619FC2007975AF /* TodoItemCoreData+CoreDataProperties.swift in Sources */,
 				FE0085472A4673250049F403 /* TodoListTableViewController+TextViewDelegate.swift in Sources */,
 				FEF8AA7D2A58EC3600640FB1 /* URLSession+CustomDataTask.swift in Sources */,
 				FE00853A2A4672530049F403 /* DatePickerTableViewCell.swift in Sources */,
@@ -479,7 +493,9 @@
 				FEFBFCFB2A54545100D430BC /* DefaultNetworkingService.swift in Sources */,
 				FE0085452A4673010049F403 /* UIColor+HEXCode.swift in Sources */,
 				FEC83E952A3CF68C00FFD551 /* CSVExtensions.swift in Sources */,
+				FECA9C512A6132A90001181C /* TodoItemsModel.xcdatamodeld in Sources */,
 				FEC83E912A3CF64200FFD551 /* ToDoItem.swift in Sources */,
+				FE148FE12A619FC2007975AF /* TodoItemCoreData+CoreDataClass.swift in Sources */,
 				FE0085492A46794F0049F403 /* NSLayoutConstraints+TableViewCellContentView.swift in Sources */,
 				FEC83E932A3CF66C00FFD551 /* FileCache.swift in Sources */,
 				FEC83E5F2A3CF1DA00FFD551 /* SceneDelegate.swift in Sources */,
@@ -657,7 +673,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "ahc.todo-app-a-handsome-cat";
+				PRODUCT_BUNDLE_IDENTIFIER = "ahc.todo-app-ahc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = minimal;
@@ -687,7 +703,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "ahc.todo-app-a-handsome-cat";
+				PRODUCT_BUNDLE_IDENTIFIER = "ahc.todo-app-ahc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = minimal;
@@ -806,6 +822,20 @@
 			productName = CocoaLumberjackSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		FECA9C4F2A6132A90001181C /* TodoItemsModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				FECA9C502A6132A90001181C /* TodoItemsModel.xcdatamodel */,
+			);
+			currentVersion = FECA9C502A6132A90001181C /* TodoItemsModel.xcdatamodel */;
+			name = TodoItemsModel.xcdatamodeld;
+			path = "todo-app-ahc/TodoItemsModel.xcdatamodeld";
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = FEC83E512A3CF1DA00FFD551 /* Project object */;
 }

--- a/todo-app-ahc/AppDelegate.swift
+++ b/todo-app-ahc/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import CocoaLumberjackSwift
+import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -43,6 +44,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7
         DDLog.add(fileLogger)
+    }
+
+    // MARK: - Core Data stack
+
+    lazy var persistentContainer: NSPersistentContainer = {
+
+        let container = NSPersistentContainer(name: "TodoItemsModel")
+        container.loadPersistentStores(completionHandler: { (_, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
     }
 
 }

--- a/todo-app-ahc/Models/FileCache+UniversalFuncs.swift
+++ b/todo-app-ahc/Models/FileCache+UniversalFuncs.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+extension FileCache {
+    func loadItems(fileName: String) {
+        switch storageMethod {
+        case .coreData:
+            loadFromCoreData()
+        case .csv:
+            loadFromCSVFile(fileName: fileName)
+        case .json:
+            loadFromJSONFile(fileName: fileName)
+        case .sql:
+            loadFromSQLDatabase(fileName: fileName)
+        }
+    }
+
+    func updateSavedFromServer(fileName: String) {
+        switch storageMethod {
+        case .coreData:
+            updateCoreDataFromServer()
+        case .csv:
+            saveToCSVFile(fileName: fileName)
+        case .json:
+            saveToJSONFile(fileName: fileName)
+        case .sql:
+            updateSQLFromServer()
+        }
+    }
+
+    func addItem(item: TodoItem, fileName: String) {
+        switch storageMethod {
+        case .coreData:
+            performCoreDataAction(.insert, item: item)
+        case .csv:
+            saveToCSVFile(fileName: fileName)
+        case .json:
+            saveToJSONFile(fileName: fileName)
+        case .sql:
+            performSQLStatement(.insert, item: item)
+        }
+    }
+
+    func updateItem(item: TodoItem, fileName: String) {
+        switch storageMethod {
+        case .coreData:
+            performCoreDataAction(.update, item: item)
+        case .csv:
+            saveToCSVFile(fileName: fileName)
+        case .json:
+            saveToJSONFile(fileName: fileName)
+        case .sql:
+            performSQLStatement(.update, item: item)
+        }
+    }
+
+    func deleteItem(item: TodoItem, fileName: String) {
+        switch storageMethod {
+        case .coreData:
+            performCoreDataAction(.delete, item: item)
+        case .csv:
+            saveToCSVFile(fileName: fileName)
+        case .json:
+            saveToJSONFile(fileName: fileName)
+        case .sql:
+            performSQLStatement(.delete, item: item)
+        }
+    }
+}

--- a/todo-app-ahc/Models/ToDoItem.swift
+++ b/todo-app-ahc/Models/ToDoItem.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 
 enum Priority: String {
     case low = "неважная"
@@ -91,6 +92,54 @@ extension TodoItem {
         if let colorString = json["color"] as? String {
             color = colorString
         }
+
+        return TodoItem(id: id,
+                        text: text,
+                        priority: priority,
+                        deadline: deadline,
+                        isDone: isDone,
+                        createdDate: Date(timeIntervalSince1970: createdDate),
+                        editedDate: editedDate,
+                        color: color)
+    }
+
+    var sqlReplaceStatement: String {
+        guard let json = json as? [String: Any] else { return "" }
+        let keys = json.keys.joined(separator: ", ")
+        let values = json.values.map({ "\"\($0)\"" }).joined(separator: ", ")
+        return "REPLACE INTO TodoItems (\(keys)) VALUES (\(values));"
+    }
+
+    static func parseSQLStatement(_ statement: OpaquePointer) -> TodoItem? {
+        guard
+            let id = sqlite3_column_text(statement, 0).flatMap({ String(cString: $0)}),
+            let text = sqlite3_column_text(statement, 1).flatMap({ String(cString: $0)}),
+            let isDone = sqlite3_column_text(statement, 4).flatMap({ Bool(String(cString: $0)) }),
+            sqlite3_column_type(statement, 5) == SQLITE_FLOAT
+        else { return nil }
+
+        let createdDate = sqlite3_column_double(statement, 5)
+
+        var priority: Priority {
+            return sqlite3_column_text(statement, 2).flatMap({ Priority(rawValue: String(cString: $0)) }) ?? .medium
+        }
+
+        var deadline: Date? {
+            if sqlite3_column_type(statement, 3) == SQLITE_FLOAT {
+                return Date(timeIntervalSince1970: sqlite3_column_double(statement, 3))
+            } else {
+                return nil
+            }
+        }
+
+        var editedDate: Date? {
+            if sqlite3_column_type(statement, 6) == SQLITE_FLOAT {
+                return Date(timeIntervalSince1970: sqlite3_column_double(statement, 6))
+            } else {
+                return nil
+            }
+        }
+        let color = sqlite3_column_text(statement, 7).flatMap({ String(cString: $0) })
 
         return TodoItem(id: id,
                         text: text,

--- a/todo-app-ahc/Models/ToDoItem.swift
+++ b/todo-app-ahc/Models/ToDoItem.swift
@@ -150,4 +150,15 @@ extension TodoItem {
                         editedDate: editedDate,
                         color: color)
     }
+
+    static func parseCoreDataItem(coreDataItem: TodoItemCoreData) -> TodoItem {
+        return TodoItem(id: coreDataItem.id,
+                        text: coreDataItem.text,
+                        priority: Priority(rawValue: coreDataItem.priority) ?? .medium,
+                        deadline: coreDataItem.deadline,
+                        isDone: coreDataItem.isDone,
+                        createdDate: coreDataItem.createdDate,
+                        editedDate: coreDataItem.editedDate,
+                        color: coreDataItem.color)
+    }
 }

--- a/todo-app-ahc/Models/TodoItemsManager.swift
+++ b/todo-app-ahc/Models/TodoItemsManager.swift
@@ -17,7 +17,7 @@ class TodoItemsManager {
     var items: [TodoItem] = []
 
     func getList(completion: @escaping () -> Void) {
-        fileCache.loadFromJSONFile(fileName: filename)
+        fileCache.loadFromSQLDatabase(fileName: filename)
         items = fileCache.items
 
         if fileCache.isDirty {
@@ -41,7 +41,7 @@ class TodoItemsManager {
                         items.append(serverItem.convertToLocal())
                     }
                     fileCache.replace(with: items)
-                    fileCache.saveToJSONFile(fileName: filename)
+                    fileCache.saveToSQLDatabase()
                     self.items = items
                 }
             } catch {
@@ -89,7 +89,7 @@ class TodoItemsManager {
     func addItem(_ item: TodoItem) {
         items.append(item)
         fileCache.add(newItem: item)
-        fileCache.saveToJSONFile(fileName: filename)
+        fileCache.saveToSQLDatabase()
 
         Task {
             let outgoing = APIOutgoing(element: TodoItemServer.convertToServer(item: item))
@@ -108,7 +108,7 @@ class TodoItemsManager {
             items[index] = item
         }
         fileCache.add(newItem: item)
-        fileCache.saveToJSONFile(fileName: filename)
+        fileCache.saveToSQLDatabase()
 
         Task {
             let outgoing = APIOutgoing(element: TodoItemServer.convertToServer(item: item))
@@ -128,7 +128,7 @@ class TodoItemsManager {
             items.remove(at: index)
         }
         fileCache.delete(byID: item.id)
-        fileCache.saveToJSONFile(fileName: filename)
+        fileCache.saveToSQLDatabase()
 
         Task {
             let fetchConfigurationRequest = APIRequest(httpMethod: "DELETE",

--- a/todo-app-ahc/Networking/DefaultNetworkingService.swift
+++ b/todo-app-ahc/Networking/DefaultNetworkingService.swift
@@ -43,6 +43,8 @@ class DefaultNetworkingService: NetworkingService {
         guard response.statusCode == 200 else {
             if response.statusCode == 500 {
                 throw NetworkingErrors.serverError
+            } else if response.statusCode == 400 {
+                throw NetworkingErrors.needToUpdateFromServer
             } else {
                 throw NetworkingErrors.unknownError
             }

--- a/todo-app-ahc/Networking/NetworkingServiceProtocol.swift
+++ b/todo-app-ahc/Networking/NetworkingServiceProtocol.swift
@@ -4,6 +4,7 @@ enum NetworkingErrors: Error {
     case formingRequest
     case wrongResponse
     case serverError
+    case needToUpdateFromServer
     case unknownError
 }
 

--- a/todo-app-ahc/SceneDelegate.swift
+++ b/todo-app-ahc/SceneDelegate.swift
@@ -55,6 +55,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+
+        // Save changes in the application's managed object context when the application transitions to the background.
+        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 
 }

--- a/todo-app-ahc/TodoItemsModel.xcdatamodeld/TodoItemsModel.xcdatamodel/contents
+++ b/todo-app-ahc/TodoItemsModel.xcdatamodeld/TodoItemsModel.xcdatamodel/contents
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="TodoItemCoreData" representedClassName=".TodoItemCoreData" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="createdDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="deadline" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="editedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="isDone" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="priority" attributeType="String"/>
+        <attribute name="text" attributeType="String"/>
+    </entity>
+</model>

--- a/todo-app-ahc/ViewControllers/TodoListTableViewController.swift
+++ b/todo-app-ahc/ViewControllers/TodoListTableViewController.swift
@@ -25,6 +25,8 @@ class TodoListTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        itemsManager.updateTableView = { self.tableView.reloadData() }
+
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: activityIndicator)
 
         NotificationCenter.default.addObserver(self,
@@ -33,7 +35,7 @@ class TodoListTableViewController: UITableViewController {
                                                object: nil)
 
         Task {
-            itemsManager.getList(completion: { self.tableView.reloadData() })
+            itemsManager.getList()
             tableView.reloadData()
         }
 

--- a/todo-app-ahc/Views/ButtonsAndImages/CheckmarkButton.swift
+++ b/todo-app-ahc/Views/ButtonsAndImages/CheckmarkButton.swift
@@ -4,7 +4,7 @@ class CheckmarkButton: UIButton {
     func setAppearance(isDone: Bool, highPriority: Bool) {
         translatesAutoresizingMaskIntoConstraints = false
 
-        var configuration = UIImage.SymbolConfiguration(pointSize: 24)
+        let configuration = UIImage.SymbolConfiguration(pointSize: 24)
 
         let doneImage = UIImage(systemName: "checkmark.circle.fill",
                               withConfiguration: configuration)


### PR DESCRIPTION
Привет!
Сделано все и на SQL, и на Core Data.
Если есть желание поиграться на девайсе/в симуляторе с разными сценариями, в классе TodoItemsManager можно переключить, какое именно хранилище используется (выставляется при инициализации FileCache). 
**ВНИМАНИЕ**! Крайне желательно при переключении поставить приложение с нуля, так как переключение используемой базы, разумеется, не обрабатывается.

Пара слов по логике.
В случае, если наша сохраненная последняя ревизия не совпала с ревизией сервера (или в случае, если мы отправились патчить данные сервера) в SQL мы дропаем всю таблицу и пересоздаем заново с полученными от сервера данными. В Core Data же в этом случае мы обновляем данными с сервера существующие записи и удаляем то, что у нас было сохранено, а на сервере уже пропало. Не уверен даже, какой подход лучше в данном случае.
Insert/Update/Delete работают по заданию.

Извини, что громоздко немножко, все равно на SwiftUI переписываться, там отрефакторю)